### PR TITLE
7 channel buffer endianness

### DIFF
--- a/src/abstractions/Adapters/ChannelAdapter.cs
+++ b/src/abstractions/Adapters/ChannelAdapter.cs
@@ -64,7 +64,7 @@ public abstract class ChannelAdapter<T> : IChannelAdapter, IInputChannelAdapter,
         }
 
         // attempt to convert the data
-        var convertedData = ConvertData( data );
+        var convertedData = ConvertData( context, data );
 
         if ( ( convertedData != null ) && ( convertedData.GetType() != data.GetType() ) )
         {
@@ -79,7 +79,7 @@ public abstract class ChannelAdapter<T> : IChannelAdapter, IInputChannelAdapter,
         return Task.CompletedTask;
     }
 
-    protected virtual object? ConvertData( object data )
+    protected virtual object? ConvertData( IAdapterContext context, object data )
     {
         var type = typeof( T );
 
@@ -88,7 +88,7 @@ public abstract class ChannelAdapter<T> : IChannelAdapter, IInputChannelAdapter,
         {
             logger?.LogDebug( "Transformed 'Byte[]' to 'WrappedByteBuffer'." );
 
-            return new WrappedByteBuffer( (byte[])data );
+            return new WrappedByteBuffer( (byte[])data, context.Channel.Buffer.Endianness );
         }
 
         // attempt an IByteBuffer to byte[] transformation

--- a/src/abstractions/DependencyInjection/ChannelOptions.cs
+++ b/src/abstractions/DependencyInjection/ChannelOptions.cs
@@ -2,6 +2,7 @@ namespace Faactory.Channels;
 
 public class ChannelOptions
 {
+    public Buffers.Endianness BufferEndianness { get; set; } = Buffers.Endianness.BigEndian;
     public IdleDetectionMode IdleDetectionMode { get; set; } = IdleDetectionMode.Auto;
     public TimeSpan IdleDetectionTimeout { get; set; } = TimeSpan.FromSeconds( 60 );
 }

--- a/src/abstractions/Handlers/ChannelHandler.cs
+++ b/src/abstractions/Handlers/ChannelHandler.cs
@@ -64,7 +64,7 @@ public abstract class ChannelHandler<T> : IChannelHandler
         }
 
         // attempt to convert the data
-        var convertedData = ConvertData( data );
+        var convertedData = ConvertData( context, data );
 
         if ( ( convertedData != null ) && ( convertedData.GetType() != data.GetType() ) )
         {
@@ -77,7 +77,7 @@ public abstract class ChannelHandler<T> : IChannelHandler
         return Task.CompletedTask;
     }
 
-    private object? ConvertData( object data )
+    private object? ConvertData( IChannelContext context, object data )
     {
         var type = typeof( T );
 
@@ -86,7 +86,7 @@ public abstract class ChannelHandler<T> : IChannelHandler
         {
             logger?.LogDebug( "Transformed 'Byte[]' to 'WrappedByteBuffer'." );
 
-            return new WrappedByteBuffer( (byte[])data );
+            return new WrappedByteBuffer( (byte[])data, context.Channel.Buffer.Endianness );
         }
 
         // attempt an IByteBuffer to byte[] transformation

--- a/src/abstractions/IChannel.cs
+++ b/src/abstractions/IChannel.cs
@@ -13,6 +13,8 @@ public interface IChannel : IDisposable
     /// </summary>
     string Id { get; }
 
+    IByteBuffer Buffer { get; }
+
     /// <summary>
     /// Gets a data holder available throughout the entire channel session
     /// </summary>

--- a/src/buffers/ByteBufferExtensions.cs
+++ b/src/buffers/ByteBufferExtensions.cs
@@ -15,7 +15,7 @@ public static class ByteBufferExtensions
             return ( source );
         }
 
-        return new WrappedByteBuffer( source.ToArray() );
+        return new WrappedByteBuffer( source.ToArray(), source.Endianness );
     }
 
     /// <summary>
@@ -30,7 +30,7 @@ public static class ByteBufferExtensions
             return ( source );
         }
 
-        return new WritableByteBuffer( source.ToArray() );
+        return new WritableByteBuffer( source.ToArray(), source.Endianness );
     }
 
     /// <summary>

--- a/src/buffers/Endianness.cs
+++ b/src/buffers/Endianness.cs
@@ -3,5 +3,5 @@ namespace Faactory.Channels.Buffers;
 public enum Endianness
 {
     BigEndian,
-    LittleEndien
+    LittleEndian
 }

--- a/src/buffers/IByteBuffer.cs
+++ b/src/buffers/IByteBuffer.cs
@@ -5,6 +5,8 @@ namespace Faactory.Channels.Buffers;
 /// </summary>
 public interface IByteBuffer
 {
+    public Endianness Endianness { get; }
+
     /// <summary>
     /// Gets if the buffer can be read
     /// </summary>

--- a/src/buffers/WrappedByteBuffer.cs
+++ b/src/buffers/WrappedByteBuffer.cs
@@ -7,16 +7,16 @@ namespace Faactory.Channels.Buffers;
 /// </summary>
 public sealed class WrappedByteBuffer : IByteBuffer
 {
-    private readonly Endianness endianness;
     private byte[] buffer;
 
     public WrappedByteBuffer( byte[] source, Endianness endianness = Endianness.BigEndian )
     {
         buffer = source;
         Offset = 0;
-        this.endianness = endianness;
+        Endianness = endianness;
     }
 
+    public Endianness Endianness { get; }
     public bool IsReadable => true;
     public bool IsWritable => false;
     public int Length => buffer.Length;
@@ -75,7 +75,7 @@ public sealed class WrappedByteBuffer : IByteBuffer
     public double GetDouble( int offset )
     {
         var span = new ReadOnlySpan<byte>( buffer, offset, sizeof( double ) );
-        var value = ( endianness == Endianness.BigEndian )
+        var value = ( Endianness == Endianness.BigEndian )
             ? BinaryPrimitives.ReadDoubleBigEndian( span )
             : BinaryPrimitives.ReadDoubleLittleEndian( span );
 
@@ -85,7 +85,7 @@ public sealed class WrappedByteBuffer : IByteBuffer
     public float GetSingle( int offset )
     {
         var span = new ReadOnlySpan<byte>( buffer, offset, sizeof( float ) );
-        var value = ( endianness == Endianness.BigEndian )
+        var value = ( Endianness == Endianness.BigEndian )
             ? BinaryPrimitives.ReadSingleBigEndian( span )
             : BinaryPrimitives.ReadSingleLittleEndian( span );
 
@@ -95,7 +95,7 @@ public sealed class WrappedByteBuffer : IByteBuffer
     public short GetInt16( int offset )
     {
         var span = new ReadOnlySpan<byte>( buffer, offset, sizeof( Int16 ) );
-        var value = ( endianness == Endianness.BigEndian )
+        var value = ( Endianness == Endianness.BigEndian )
             ? BinaryPrimitives.ReadInt16BigEndian( span )
             : BinaryPrimitives.ReadInt16LittleEndian( span );
 
@@ -105,7 +105,7 @@ public sealed class WrappedByteBuffer : IByteBuffer
     public int GetInt32( int offset )
     {
         var span = new ReadOnlySpan<byte>( buffer, offset, sizeof( Int32 ) );
-        var value = ( endianness == Endianness.BigEndian )
+        var value = ( Endianness == Endianness.BigEndian )
             ? BinaryPrimitives.ReadInt32BigEndian( span )
             : BinaryPrimitives.ReadInt32LittleEndian( span );
 
@@ -115,7 +115,7 @@ public sealed class WrappedByteBuffer : IByteBuffer
     public long GetInt64( int offset )
     {
         var span = new ReadOnlySpan<byte>( buffer, offset, sizeof( Int64 ) );
-        var value = ( endianness == Endianness.BigEndian )
+        var value = ( Endianness == Endianness.BigEndian )
             ? BinaryPrimitives.ReadInt64BigEndian( span )
             : BinaryPrimitives.ReadInt64LittleEndian( span );
 
@@ -125,7 +125,7 @@ public sealed class WrappedByteBuffer : IByteBuffer
     public ushort GetUInt16( int offset )
     {
         var span = new ReadOnlySpan<byte>( buffer, offset, sizeof( UInt16 ) );
-        var value = ( endianness == Endianness.BigEndian )
+        var value = ( Endianness == Endianness.BigEndian )
             ? BinaryPrimitives.ReadUInt16BigEndian( span )
             : BinaryPrimitives.ReadUInt16LittleEndian( span );
 
@@ -135,7 +135,7 @@ public sealed class WrappedByteBuffer : IByteBuffer
     public uint GetUInt32( int offset )
     {
         var span = new ReadOnlySpan<byte>( buffer, offset, sizeof( UInt32 ) );
-        var value = ( endianness == Endianness.BigEndian )
+        var value = ( Endianness == Endianness.BigEndian )
             ? BinaryPrimitives.ReadUInt32BigEndian( span )
             : BinaryPrimitives.ReadUInt32LittleEndian( span );
 
@@ -145,7 +145,7 @@ public sealed class WrappedByteBuffer : IByteBuffer
     public ulong GetUInt64( int offset )
     {
         var span = new ReadOnlySpan<byte>( buffer, offset, sizeof( UInt64 ) );
-        var value = ( endianness == Endianness.BigEndian )
+        var value = ( Endianness == Endianness.BigEndian )
             ? BinaryPrimitives.ReadUInt64BigEndian( span )
             : BinaryPrimitives.ReadUInt64LittleEndian( span );
 

--- a/src/buffers/WrappedByteBuffer.cs
+++ b/src/buffers/WrappedByteBuffer.cs
@@ -69,7 +69,7 @@ public sealed class WrappedByteBuffer : IByteBuffer
     {
         var dest = GetBytes( offset, length );
 
-        return new WrappedByteBuffer( dest );
+        return new WrappedByteBuffer( dest, Endianness );
     }
 
     public double GetDouble( int offset )
@@ -184,7 +184,7 @@ public sealed class WrappedByteBuffer : IByteBuffer
     {
         var value = ReadBytes( length );
 
-        return new WrappedByteBuffer( value );
+        return new WrappedByteBuffer( value, Endianness );
     }
 
     public double ReadDouble()

--- a/src/buffers/WritableByteBuffer.cs
+++ b/src/buffers/WritableByteBuffer.cs
@@ -7,27 +7,27 @@ namespace Faactory.Channels.Buffers;
 /// </summary>
 public sealed class WritableByteBuffer : IByteBuffer
 {
-    private readonly Endianness endianness;
     private readonly List<byte> buffer;
 
     public WritableByteBuffer( Endianness endianness = Endianness.BigEndian )
     {
         buffer = new List<byte>();
-        this.endianness = endianness;
+        Endianness = endianness;
     }
 
     public WritableByteBuffer( byte[] source, Endianness endianness = Endianness.BigEndian )
     {
         buffer = new List<byte>( source );
-        this.endianness = endianness;
+        Endianness = endianness;
     }
 
     public WritableByteBuffer( int capacity, Endianness endianness = Endianness.BigEndian )
     {
         buffer = new List<byte>( capacity );
-        this.endianness = endianness;
+        Endianness = endianness;
     }
 
+    public Endianness Endianness { get; }
     public bool IsReadable => false;
     public bool IsWritable => true;
     public int Length => buffer.Count;
@@ -164,7 +164,7 @@ public sealed class WritableByteBuffer : IByteBuffer
     public IByteBuffer WriteDouble( double value )
     {
         var span = new Span<byte>( new byte[ sizeof( double ) ]);
-        if ( endianness == Endianness.BigEndian )
+        if ( Endianness == Endianness.BigEndian )
         {
             BinaryPrimitives.WriteDoubleBigEndian( span, value );
         }
@@ -179,7 +179,7 @@ public sealed class WritableByteBuffer : IByteBuffer
     public IByteBuffer WriteSingle( float value )
     {
         var span = new Span<byte>( new byte[ sizeof( float ) ]);
-        if ( endianness == Endianness.BigEndian )
+        if ( Endianness == Endianness.BigEndian )
         {
             BinaryPrimitives.WriteSingleBigEndian( span, value );
         }
@@ -194,7 +194,7 @@ public sealed class WritableByteBuffer : IByteBuffer
     public IByteBuffer WriteInt16( Int16 value )
     {
         var span = new Span<byte>( new byte[ sizeof( Int16 ) ]);
-        if ( endianness == Endianness.BigEndian )
+        if ( Endianness == Endianness.BigEndian )
         {
             BinaryPrimitives.WriteInt16BigEndian( span, value );
         }
@@ -209,7 +209,7 @@ public sealed class WritableByteBuffer : IByteBuffer
     public IByteBuffer WriteInt32( Int32 value )
     {
         var span = new Span<byte>( new byte[ sizeof( Int32 ) ]);
-        if ( endianness == Endianness.BigEndian )
+        if ( Endianness == Endianness.BigEndian )
         {
             BinaryPrimitives.WriteInt32BigEndian( span, value );
         }
@@ -224,7 +224,7 @@ public sealed class WritableByteBuffer : IByteBuffer
     public IByteBuffer WriteInt64( Int64 value )
     {
         var span = new Span<byte>( new byte[ sizeof( Int64 ) ]);
-        if ( endianness == Endianness.BigEndian )
+        if ( Endianness == Endianness.BigEndian )
         {
             BinaryPrimitives.WriteInt64BigEndian( span, value );
         }
@@ -239,7 +239,7 @@ public sealed class WritableByteBuffer : IByteBuffer
     public IByteBuffer WriteUInt16( UInt16 value )
     {
         var span = new Span<byte>( new byte[ sizeof( UInt16 ) ]);
-        if ( endianness == Endianness.BigEndian )
+        if ( Endianness == Endianness.BigEndian )
         {
             BinaryPrimitives.WriteUInt16BigEndian( span, value );
         }
@@ -254,7 +254,7 @@ public sealed class WritableByteBuffer : IByteBuffer
     public IByteBuffer WriteUInt32( UInt32 value )
     {
         var span = new Span<byte>( new byte[ sizeof( UInt32 ) ]);
-        if ( endianness == Endianness.BigEndian )
+        if ( Endianness == Endianness.BigEndian )
         {
             BinaryPrimitives.WriteUInt32BigEndian( span, value );
         }
@@ -269,7 +269,7 @@ public sealed class WritableByteBuffer : IByteBuffer
     public IByteBuffer WriteUInt64( UInt64 value )
     {
         var span = new Span<byte>( new byte[ sizeof( UInt64 ) ]);
-        if ( endianness == Endianness.BigEndian )
+        if ( Endianness == Endianness.BigEndian )
         {
             BinaryPrimitives.WriteUInt64BigEndian( span, value );
         }

--- a/src/channels/Channel.cs
+++ b/src/channels/Channel.cs
@@ -19,7 +19,8 @@ public abstract class Channel : ConnectedSocket, IChannel
     public Channel( IServiceScope serviceScope
         , ILoggerFactory loggerFactory
         , Socket socket
-        , IIdleChannelMonitor? idleChannelMonitor)
+        , IIdleChannelMonitor? idleChannelMonitor
+        , Buffers.Endianness bufferEndianness )
         : base( loggerFactory, socket )
     {
         logger = loggerFactory.CreateLogger<IChannel>();
@@ -30,6 +31,8 @@ public abstract class Channel : ConnectedSocket, IChannel
         {
             new OutputChannelHandler( loggerFactory )
         } );
+
+        Buffer = new WritableByteBuffer( bufferEndianness );
 
         idleMonitor = idleChannelMonitor;
         idleMonitor?.Start( this );
@@ -43,7 +46,7 @@ public abstract class Channel : ConnectedSocket, IChannel
     internal IServiceProvider ServiceProvider => channelScope.ServiceProvider;
     internal IChannelInfo Info => new ChannelInfo( this );
 
-    public IByteBuffer Buffer { get; private set; } = new WritableByteBuffer();
+    public IByteBuffer Buffer { get; private set; }
 
     public DateTimeOffset Created { get; } = DateTimeOffset.UtcNow;
     public DateTimeOffset? LastReceived { get; private set; }

--- a/src/channels/ClientChannel.cs
+++ b/src/channels/ClientChannel.cs
@@ -17,8 +17,9 @@ public class ClientChannel : Channel
         , IEnumerable<IChannelAdapter> inputAdapters
         , IEnumerable<IChannelAdapter> outputAdapters
         , IEnumerable<IChannelHandler> inputHandlers
-        , IIdleChannelMonitor? idleChannelMonitor )
-        : base( serviceScope, loggerFactory, socket, idleChannelMonitor )
+        , IIdleChannelMonitor? idleChannelMonitor
+        , Buffers.Endianness bufferEndianness )
+        : base( serviceScope, loggerFactory, socket, idleChannelMonitor, bufferEndianness )
     {
         Input = new ChannelPipeline(  loggerFactory, inputAdapters, inputHandlers );
         Output = new ChannelPipeline( loggerFactory, outputAdapters, new IChannelHandler[]
@@ -31,12 +32,14 @@ public class ClientChannel : Channel
         , ILoggerFactory loggerFactory
         , Socket socket
         , IdleDetectionMode idleDetectionMode
-        , TimeSpan idleDetectionTimeout )
+        , TimeSpan idleDetectionTimeout
+        , Buffers.Endianness bufferEndianness )
         : base( 
               serviceScope
             , loggerFactory
             , socket
-            , new IdleChannelMonitor( loggerFactory, idleDetectionMode, idleDetectionTimeout ) )
+            , new IdleChannelMonitor( loggerFactory, idleDetectionMode, idleDetectionTimeout )
+            , bufferEndianness )
     { }
 
     public override async Task CloseAsync()

--- a/src/channels/Factory/ClientChannelFactory.cs
+++ b/src/channels/Factory/ClientChannelFactory.cs
@@ -48,7 +48,8 @@ internal class ClientChannelFactory : IClientChannelFactory
             , inputAdapters
             , outputAdapters
             , inputHandlers
-            , idleChannelMonitor );
+            , idleChannelMonitor
+            , options.BufferEndianness );
 
         channel.BeginReceive();
 

--- a/src/channels/Factory/ServiceChannelFactory.cs
+++ b/src/channels/Factory/ServiceChannelFactory.cs
@@ -39,7 +39,8 @@ internal class ServiceChannelFactory : IServiceChannelFactory
             , inputAdapters
             , outputAdapters
             , inputHandlers
-            , idleChannelMonitor );
+            , idleChannelMonitor
+            , options.BufferEndianness );
 
         channel.BeginReceive();
 

--- a/src/channels/ServiceChannel.cs
+++ b/src/channels/ServiceChannel.cs
@@ -16,8 +16,9 @@ internal sealed class ServiceChannel : Channel
         , IEnumerable<IChannelAdapter> inputAdapters
         , IEnumerable<IChannelAdapter> outputAdapters
         , IEnumerable<IChannelHandler> inputHandlers
-        , IIdleChannelMonitor? idleChannelMonitor )
-        : base( serviceScope, loggerFactory, socket, idleChannelMonitor )
+        , IIdleChannelMonitor? idleChannelMonitor
+        , Endianness bufferEndianness )
+        : base( serviceScope, loggerFactory, socket, idleChannelMonitor, bufferEndianness )
     {
         Input = new ChannelPipeline(  loggerFactory, inputAdapters, inputHandlers );
         Output = new ChannelPipeline( loggerFactory, outputAdapters, new IChannelHandler[]

--- a/tests/Utils/FakeChannel.cs
+++ b/tests/Utils/FakeChannel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Faactory.Channels;
+using Faactory.Channels.Buffers;
 using Faactory.Collections;
 
 public class FakeChannel : IChannel
@@ -14,6 +15,8 @@ public class FakeChannel : IChannel
     public DateTimeOffset? LastReceived => throw new NotImplementedException();
 
     public DateTimeOffset? LastSent => throw new NotImplementedException();
+
+    public IByteBuffer Buffer => throw new NotImplementedException();
 
     public Task CloseAsync()
     {

--- a/tests/Utils/FakeChannel.cs
+++ b/tests/Utils/FakeChannel.cs
@@ -16,7 +16,7 @@ public class FakeChannel : IChannel
 
     public DateTimeOffset? LastSent => throw new NotImplementedException();
 
-    public IByteBuffer Buffer => throw new NotImplementedException();
+    public IByteBuffer Buffer { get; } = new WritableByteBuffer();
 
     public Task CloseAsync()
     {


### PR DESCRIPTION
The default endianness of the buffers allocated by a channel is now defined by a channel option. The default is still `BigEndian`.

```csharp
IChannelBuilder builder = ...;

builder.Configure( options =>
{
    options.BufferEndianness = Endianness.LittleEndian;
} );
```

Creating new buffers with `MakeReadOnly` or `MakeWritable` also inherits the source endianness.