### PR TITLE
9 generic adapters

### DIFF
--- a/src/abstractions/Adapters/ChannelAdapter.cs
+++ b/src/abstractions/Adapters/ChannelAdapter.cs
@@ -8,7 +8,7 @@ namespace Faactory.Channels.Adapters;
 /// Base class for a channel adapter
 /// </summary>
 /// <typeparam name="T">The data type</typeparam>
-public abstract class ChannelAdapter<T> : IChannelAdapter, IInputChannelAdapter, IOutputChannelAdapter
+public abstract class ChannelAdapter<T> : IChannelAdapter
 {
     private ILogger? logger;
 

--- a/src/abstractions/Adapters/IChannelAdapter.cs
+++ b/src/abstractions/Adapters/IChannelAdapter.cs
@@ -12,13 +12,3 @@ public interface IChannelAdapter
     /// <param name="data">The data to adapt</param>
     Task ExecuteAsync( IAdapterContext context, object data );
 }
-
-/// <summary>
-/// A channel adapter that can be used on the input pipeline
-/// </summary>
-public interface IInputChannelAdapter {}
-
-/// <summary>
-/// A channel adapter that can be used on the output pipeline
-/// </summary>
-public interface IOutputChannelAdapter {}

--- a/src/abstractions/Adapters/IInputChannelAdapter.cs
+++ b/src/abstractions/Adapters/IInputChannelAdapter.cs
@@ -1,0 +1,6 @@
+namespace Faactory.Channels.Adapters;
+
+/// <summary>
+/// A channel adapter that can be used on the input pipeline
+/// </summary>
+public interface IInputChannelAdapter {}

--- a/src/abstractions/Adapters/IOutputChannelAdapter.cs
+++ b/src/abstractions/Adapters/IOutputChannelAdapter.cs
@@ -1,0 +1,6 @@
+namespace Faactory.Channels.Adapters;
+
+/// <summary>
+/// A channel adapter that can be used on the output pipeline
+/// </summary>
+public interface IOutputChannelAdapter {}

--- a/src/abstractions/abstractions.csproj
+++ b/src/abstractions/abstractions.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Faactory.Channels.Abstractions</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>Goncalo Oliveira</Authors>
     <Description>Channels</Description>
     <RepositoryUrl>https://github.com/goncalo-oliveira/channels</RepositoryUrl>

--- a/src/buffers/buffers.csproj
+++ b/src/buffers/buffers.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Faactory.Channels.Buffers</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>Goncalo Oliveira</Authors>
     <Description>Channels Buffers</Description>
     <RepositoryUrl>https://github.com/goncalo-oliveira/channels</RepositoryUrl>

--- a/src/channels/Adapters/AnonymousChannelAdapter.cs
+++ b/src/channels/Adapters/AnonymousChannelAdapter.cs
@@ -6,7 +6,7 @@ namespace Faactory.Channels.Adapters;
 /// An anonymous channel adapter
 /// </summary>
 /// <typeparam name="T">The expected data type</typeparam>
-public sealed class AnonymousChannelAdapter<T> : ChannelAdapter<T>
+public sealed class AnonymousChannelAdapter<T> : ChannelAdapter<T>, IInputChannelAdapter, IOutputChannelAdapter
 {
     private readonly Func<IAdapterContext, T, Task> execute;
 

--- a/src/channels/Adapters/BufferLengthAdapter.cs
+++ b/src/channels/Adapters/BufferLengthAdapter.cs
@@ -28,7 +28,7 @@ public class BufferLengthAdapterOptions
 /// <summary>
 /// This adapter ensures the length of the input buffer doesn't exceed a maximum value. Configure with BufferLengthAdapterOptions.
 /// </summary>
-public sealed class BufferLengthAdapter : ChannelAdapter<IByteBuffer>
+public sealed class BufferLengthAdapter : ChannelAdapter<IByteBuffer>, IInputChannelAdapter
 {
     private readonly int maxBufferSize;
     private readonly bool closeChannel;

--- a/src/channels/channels.csproj
+++ b/src/channels/channels.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Faactory.Channels</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>Goncalo Oliveira</Authors>
     <Description>Channels</Description>
     <RepositoryUrl>https://github.com/goncalo-oliveira/channels</RepositoryUrl>

--- a/tests/ScopedServiceTests.cs
+++ b/tests/ScopedServiceTests.cs
@@ -19,7 +19,7 @@ public class ScopedServiceTests
         public string Id { get; } = Guid.NewGuid().ToString( "N" );
     }
 
-    private class MyAdapter : ChannelAdapter<string>
+    private class MyAdapter : ChannelAdapter<string>, IInputChannelAdapter
     {
         private readonly string id;
 


### PR DESCRIPTION
Removed `IInputChannelAdapter and `IOutputChannelAdapter` from abstract classes.