### PR TITLE
Reset offset upon discarding

### DIFF
--- a/src/buffers/WrappedByteBuffer.cs
+++ b/src/buffers/WrappedByteBuffer.cs
@@ -28,7 +28,7 @@ public sealed class WrappedByteBuffer : IByteBuffer
     {
         Array.Resize<byte>( ref buffer, 0 );
 
-        Offset = 0;
+        ResetOffset();
 
         return ( this );
     }
@@ -45,7 +45,7 @@ public sealed class WrappedByteBuffer : IByteBuffer
 
         buffer = dest;
 
-        Offset = 0;
+        ResetOffset();
 
         return ( this );
     }

--- a/src/buffers/WrappedByteBuffer.cs
+++ b/src/buffers/WrappedByteBuffer.cs
@@ -28,6 +28,8 @@ public sealed class WrappedByteBuffer : IByteBuffer
     {
         Array.Resize<byte>( ref buffer, 0 );
 
+        Offset = 0;
+
         return ( this );
     }
 
@@ -42,6 +44,8 @@ public sealed class WrappedByteBuffer : IByteBuffer
         Array.Copy( buffer, Offset, dest, 0, buffer.Length - Offset );
 
         buffer = dest;
+
+        Offset = 0;
 
         return ( this );
     }

--- a/tests/WrappedByteBufferTests.cs
+++ b/tests/WrappedByteBufferTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Faactory.Channels;
+using Faactory.Channels.Buffers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+public class WrappedByteBufferTests
+{
+    [Fact]
+    public void TestDiscardRead()
+    {
+        var buffer = new WrappedByteBuffer( new byte[]
+        {
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09
+        } );
+
+        buffer.SkipBytes( 9 );
+        buffer.DiscardReadBytes();
+
+        Assert.Equal( 0, buffer.Offset );
+        Assert.Equal( 1, buffer.ReadableBytes );
+    }
+
+    [Fact]
+    public void TestDiscardAll()
+    {
+        var buffer = new WrappedByteBuffer( new byte[]
+        {
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09
+        } );
+
+        buffer.SkipBytes( 5 );
+        buffer.DiscardAll();
+
+        Assert.Equal( 0, buffer.Offset );
+        Assert.Equal( 0, buffer.ReadableBytes );
+    }
+}


### PR DESCRIPTION
Both `DiscaradReadBytes()` and `DiscardAll()` were not resetting the offset, which caused the number of readable bytes to be wrong.