### PR TITLE
fixed #30

### DIFF
--- a/src/buffers/Extensions/ByteBufferExtensions.cs
+++ b/src/buffers/Extensions/ByteBufferExtensions.cs
@@ -12,7 +12,16 @@ public static class ByteBufferExtensions
     {
         if ( source.IsReadable && !source.IsWritable )
         {
-            // already read-only
+            /*
+            the source buffer is already read-only.
+            we might still need to change the endianness, though.
+            */
+            if ( ( endianness != null ) && endianness != source.Endianness )
+            {
+                return new WrappedByteBuffer( source.ToArray(), endianness.Value );
+            }
+
+            // no need to create a new buffer wrapper
             return ( source );
         }
 
@@ -29,6 +38,15 @@ public static class ByteBufferExtensions
     {
         if ( source.IsWritable )
         {
+            /*
+            the source buffer is already writable.
+            we might still need to change the endianness, though.
+            */
+            if ( ( endianness != null ) && endianness != source.Endianness )
+            {
+                return new WritableByteBuffer( source.ToArray(), endianness.Value );
+            }
+
             return ( source );
         }
 

--- a/tests/ByteBufferTests.cs
+++ b/tests/ByteBufferTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Faactory.Channels;
+using Faactory.Channels.Buffers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+public class ByteBufferTests
+{
+    [Fact]
+    public void TestMakeReadOnly()
+    {
+        /*
+        When the buffer is already read-only and the endianness doesn't change
+        the instance returned should be the same as the original.
+        */
+        IByteBuffer source = new WrappedByteBuffer( new byte[] { 0x00, 0x01 }, Endianness.BigEndian );
+        IByteBuffer readOnly = source.MakeReadOnly();
+
+        Assert.Equal( source, readOnly );
+        Assert.True( readOnly.IsReadable );
+        Assert.False( readOnly.IsWritable );
+
+        /*
+        However, if the endianness changes, the returned instance should be
+        a new instance with the new endianness, even if the buffer is already
+        read-only.
+        */
+
+        source = new WrappedByteBuffer( new byte[] { 0x00, 0x01 }, Endianness.BigEndian );
+        readOnly = source.MakeReadOnly( Endianness.LittleEndian );
+
+        Assert.NotEqual( source, readOnly );
+        Assert.True( readOnly.IsReadable );
+        Assert.False( readOnly.IsWritable );
+
+        /*
+        If the buffer is not read-only, the returned instance should be a new
+        instance with the same endianness.
+        */
+
+        source = new WritableByteBuffer()
+            .WriteBytes( new byte[] { 0x00, 0x01 } );
+        
+        readOnly = source.MakeReadOnly();
+
+        Assert.NotEqual( source, readOnly );
+        Assert.True( readOnly.IsReadable );
+        Assert.False( readOnly.IsWritable );
+    }
+
+    [Fact]
+    public void TestMakeWritable()
+    {
+        /*
+        When the buffer is already writable and the endianness doesn't change
+        the instance returned should be the same as the original.
+        */
+        IByteBuffer source = new WritableByteBuffer()
+            .WriteBytes( new byte[] { 0x00, 0x01 } );
+
+        IByteBuffer writable = source.MakeWritable();
+
+        Assert.Equal( source, writable );
+        Assert.True( writable.IsWritable );
+        Assert.False( writable.IsReadable );
+
+        /*
+        However, if the endianness changes, the returned instance should be
+        a new instance with the new endianness, even if the buffer is already
+        writable.
+        */
+
+        source = new WritableByteBuffer()
+            .WriteBytes( new byte[] { 0x00, 0x01 } );
+
+        writable = source.MakeWritable( Endianness.LittleEndian );
+
+        Assert.NotEqual( source, writable );
+        Assert.True( writable.IsWritable );
+        Assert.False( writable.IsReadable );
+
+        /*
+        If the buffer is not writable, the returned instance should be a new
+        instance with the same endianness.
+        */
+
+        source = new WrappedByteBuffer( new byte[] { 0x00, 0x01 }, Endianness.BigEndian );
+        writable = source.MakeWritable();
+
+        Assert.NotEqual( source, writable );
+        Assert.True( writable.IsWritable );
+        Assert.False( writable.IsReadable );
+    }
+}


### PR DESCRIPTION
Endianness is now verified and a new instance is returned if different, even when the buffer is already readable/writable. Tests added.