### PR TITLE
Removed duplicate extension definitions

### DIFF
--- a/src/channels/Adapters/Anonymous/AnonymousAdapterBuilderExtensions.cs
+++ b/src/channels/Adapters/Anonymous/AnonymousAdapterBuilderExtensions.cs
@@ -45,44 +45,6 @@ public static class AnonymousAdapterChannelBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a transient service for the anonymous channel handler to the input pipeline
-    /// </summary>
-    /// <param name="action">The anonymous handler action</param>
-    /// <typeparam name="TData">The data type expected by the handler</typeparam>
-    public static IChannelBuilder AddInputHandler<TData>( this IChannelBuilder builder, Action<IChannelContext, TData> action )
-    {
-        builder.Services.AddTransient<IChannelHandler, AnonymousChannelHandler<TData>>( provider =>
-        {
-            return new AnonymousChannelHandler<TData>( async ( context, data ) =>
-            {
-                await Task.Run( () => action.Invoke( context, data ) )
-                    .ConfigureAwait( false );
-            } );
-        });
-
-        return ( builder );
-    }
-
-    /// <summary>
-    /// Adds a transient service for the anonymous channel handler to the input pipeline
-    /// </summary>
-    /// <param name="action">The anonymous handler action</param>
-    /// <typeparam name="TData">The data type expected by the handler</typeparam>
-    public static IChannelBuilder AddInputHandler<TData>( this IChannelBuilder builder, Action<IServiceProvider, IChannelContext, TData> action )
-    {
-        builder.Services.AddTransient<IChannelHandler, AnonymousChannelHandler<TData>>( provider =>
-        {
-            return new AnonymousChannelHandler<TData>( async ( context, data ) =>
-            {
-                await Task.Run( () => action.Invoke( provider, context, data ) )
-                    .ConfigureAwait( false );
-            } );
-        });
-
-        return ( builder );
-    }
-
-    /// <summary>
     /// Adds a transient service for the anonymous channel adapter to the output pipeline
     /// </summary>
     /// <param name="action">The anonymous adapter action</param>


### PR DESCRIPTION
These definitions on the adapter were duplicate

```
// AnonymousAdapterBuilderExtensions.cs
IChannelBuilder AddInputHandler<TData>(this IChannelBuilder builder, Action<IChannelContext, TData> action);
IChannelBuilder AddInputHandler<TData>(this IChannelBuilder builder, Action<IServiceProvider, IChannelContext, TData> action);
```
