### PR TITLE
Add Channel Registry

### DIFF
--- a/src/channels/Builders/ServiceExtensions.cs
+++ b/src/channels/Builders/ServiceExtensions.cs
@@ -52,6 +52,15 @@ public static class ChannelsBuilderServiceExtensions
         */
         services.TryAddTransient<IChannelFactory, ChannelFactory>();
 
+        /*
+        Channel registry is used to keep track of active channels.
+        It also serves as a channel monitor to update activity information to each channel handle.
+        */
+        services.AddSingleton<ChannelRegistry>();
+        services.AddSingleton<IChannelRegistrar>( sp => sp.GetRequiredService<ChannelRegistry>() );
+        services.AddSingleton<IChannelRegistry>( sp => sp.GetRequiredService<ChannelRegistry>() );
+        services.AddSingleton<IChannelMonitor>( sp => sp.GetRequiredService<ChannelRegistry>() );
+
         return services;
     }
 }

--- a/src/channels/Client/TcpClient.cs
+++ b/src/channels/Client/TcpClient.cs
@@ -129,6 +129,7 @@ internal sealed class TcpClient : IChannelsClient
         return new TcpChannel(
             Scope,
             socket,
+            channelName,
             options.ChannelOptions,
             inputPipeline,
             outputPipeline,

--- a/src/channels/Client/UdpClient.cs
+++ b/src/channels/Client/UdpClient.cs
@@ -96,6 +96,7 @@ internal sealed class ChannelsUdpClient : IChannelsClient
         var channel = new UdpChannel(
               scope
             , new UdpRemote( Socket, null )
+            , channelName
             , options.ChannelOptions
             , inputPipeline
             , outputPipeline

--- a/src/channels/Registry/ChannelHandle.cs
+++ b/src/channels/Registry/ChannelHandle.cs
@@ -1,0 +1,29 @@
+
+
+namespace Faactory.Channels;
+
+internal sealed class ChannelHandle( IChannel channel ) : IChannelHandle
+{
+    public string Id => channel.Id;
+
+    public string Name => channel.Name;
+
+    public DateTimeOffset Created => channel.Created;
+
+    public DateTimeOffset LastReceived { get; set; } = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset LastSent { get; set; } = DateTimeOffset.UtcNow;
+
+    public TimeSpan Duration => DateTimeOffset.UtcNow - Created;
+
+    public TimeSpan IdleTime => DateTimeOffset.UtcNow - ( LastReceived > LastSent ? LastReceived : LastSent );
+
+    public long BytesReceived { get; set; }
+
+    public long BytesSent { get; set; }
+
+    public IReadOnlyDictionary<string, object> Data => channel.Data.AsReadOnly();
+
+    public Task CloseAsync()
+        => channel.CloseAsync();
+}

--- a/src/channels/Registry/ChannelRegistry.cs
+++ b/src/channels/Registry/ChannelRegistry.cs
@@ -1,0 +1,66 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Faactory.Channels;
+
+internal sealed class ChannelRegistry : IChannelRegistrar, IChannelRegistry, IChannelMonitor
+{
+    private readonly ConcurrentDictionary<string, ChannelHandle> channels = new();
+
+    public IReadOnlyCollection<IChannelHandle> Channels => (IReadOnlyCollection<IChannelHandle>)channels.Values;
+
+    public bool TryGet( string channelId, [MaybeNullWhen(false)] out IChannelHandle handle )
+    {
+        if ( channels.TryGetValue( channelId, out var channelHandle ) )
+        {
+            handle = channelHandle;
+
+            return true;
+        }
+
+        handle = null;
+
+        return false;
+    }
+
+    public void Register( IChannel channel )
+    {
+        channels.TryAdd( channel.Id, new ChannelHandle( channel ) );
+    }
+
+    #region IChannelMonitor
+
+    public void ChannelClosed( IChannelInfo channelInfo )
+    {
+        channels.TryRemove( channelInfo.Id, out _ );
+    }
+
+    public void ChannelCreated( IChannelInfo channelInfo )
+    {
+        // do nothing.
+        // registration is done explicitly since monitor events don't provide the channel instance.
+    }
+
+    public void CustomEvent( IChannelInfo channelInfo, string name, object? data )
+    { }
+
+    public void DataReceived( IChannelInfo channelInfo, ReadOnlySpan<byte> data )
+    {
+        if ( channels.TryGetValue( channelInfo.Id, out var handle ) )
+        {
+            handle.LastReceived = DateTimeOffset.UtcNow;
+            handle.BytesReceived += data.Length;
+        }
+    }
+
+    public void DataSent( IChannelInfo channelInfo, ReadOnlySpan<byte> data )
+    {
+        if ( channels.TryGetValue( channelInfo.Id, out var handle ) )
+        {
+            handle.LastSent = DateTimeOffset.UtcNow;
+            handle.BytesSent += data.Length;
+        }
+    }
+
+    #endregion
+}

--- a/src/channels/Transport/Tcp/TcpChannel.cs
+++ b/src/channels/Transport/Tcp/TcpChannel.cs
@@ -16,6 +16,7 @@ internal sealed class TcpChannel : Channel
     internal TcpChannel( 
           IServiceScope serviceScope
         , Socket socket
+        , string channelName
         , ChannelOptions options
         , IChannelPipeline inputPipeline
         , IChannelPipeline outputPipeline
@@ -31,6 +32,7 @@ internal sealed class TcpChannel : Channel
         Buffer = new WritableByteBuffer( options.BufferEndianness );
         Timeout = options.IdleTimeout;
         Socket = socket;
+        Name = channelName;
         Input = inputPipeline;
         Output = outputPipeline;
 

--- a/src/channels/Transport/Tcp/TcpListener.cs
+++ b/src/channels/Transport/Tcp/TcpListener.cs
@@ -140,6 +140,7 @@ internal sealed class TcpListener : IHostedService, IDisposable, IAsyncDisposabl
         var channel = new TcpChannel(
               scope
             , channelSocket
+            , Name
             , options
             , inputPipeline
             , outputPipeline

--- a/src/channels/Transport/Udp/UdpChannel.cs
+++ b/src/channels/Transport/Udp/UdpChannel.cs
@@ -14,6 +14,7 @@ internal sealed class UdpChannel : Channel
     internal UdpChannel( 
           IServiceScope serviceScope
         , UdpRemote udpRemote
+        , string channelName
         , ChannelOptions options
         , IChannelPipeline inputPipeline
         , IChannelPipeline outputPipeline
@@ -26,6 +27,7 @@ internal sealed class UdpChannel : Channel
         loggerScope = logger.BeginScope( $"udp-{Id[..7]}" );
 
         Remote = udpRemote;
+        Name = channelName;
         Buffer = new WritableByteBuffer( options.BufferEndianness );
         Timeout = options.IdleTimeout;
         Input = inputPipeline;

--- a/src/channels/Transport/Udp/UdpListener.cs
+++ b/src/channels/Transport/Udp/UdpListener.cs
@@ -129,6 +129,7 @@ internal sealed class UdpListener( IServiceProvider serviceProvider, string chan
         var channel = new UdpChannel(
               scope
             , remote
+            , Name
             , options
             , inputPipeline
             , outputPipeline

--- a/src/core/Channel.cs
+++ b/src/core/Channel.cs
@@ -13,6 +13,7 @@ public abstract class Channel : IChannel, IAsyncDisposable
 {
     private readonly ILogger logger;
     private readonly CancellationTokenSource cts = new();
+    private readonly IChannelRegistrar registrar;
     private readonly Lazy<IChannelMonitor[]> monitors;
     private readonly Func<IChannelInfo, TagList> metricsTagsFactory;
     private Task initializeTask = Task.CompletedTask;
@@ -29,6 +30,9 @@ public abstract class Channel : IChannel, IAsyncDisposable
 
         logger = serviceScope.ServiceProvider.GetRequiredService<ILoggerFactory>()
             .CreateLogger<Channel>();
+
+        registrar = serviceScope.ServiceProvider.GetService<IChannelRegistrar>()
+            ?? NullChannelRegistrar.Instance;
 
         monitors = new( () => ServiceProvider.GetServices<IChannelMonitor>().ToArray() );
 
@@ -96,6 +100,11 @@ public abstract class Channel : IChannel, IAsyncDisposable
     /// The unique identifier for the channel.
     /// </summary>
     public string Id { get; } = Guid.NewGuid().ToString( "N" );
+
+    /// <summary>
+    /// The name of the channel, which corresponds to the channel configuration name.
+    /// </summary>
+    public string Name { get; protected set; } = string.Empty;
 
     private volatile bool isClosed;
 
@@ -320,6 +329,7 @@ public abstract class Channel : IChannel, IAsyncDisposable
     {
         Metrics.ActiveChannels.Add( 1 );
 
+        registrar.Register( this );
         monitors.Value.InvokeAll( x => x.ChannelCreated( Info ) );
     }
 

--- a/src/core/Detached/DetachedChannel.cs
+++ b/src/core/Detached/DetachedChannel.cs
@@ -15,6 +15,12 @@ public sealed class DetachedChannel : IChannel
     public string Id { get; } = Guid.NewGuid().ToString( "N" );
 
     /// <summary>
+    /// Gets the name of the channel, which corresponds to the channel configuration name.
+    /// Always returns "DetachedChannel" for a detached channel.
+    /// </summary>
+    public string Name { get; } = "DetachedChannel";
+
+    /// <summary>
     /// Gets the channel data, a dictionary of string keys and object values that can be used to store any relevant information about the channel
     /// </summary>
     public ChannelData Data { get; } = [];

--- a/src/core/IChannel.cs
+++ b/src/core/IChannel.cs
@@ -11,6 +11,11 @@ public interface IChannel : IDisposable, IAsyncDisposable
     string Id { get; }
 
     /// <summary>
+    /// Gets the name of the channel, which corresponds to the channel configuration name.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
     /// Gets if the channel is closed
     /// </summary>
     bool IsClosed { get; }

--- a/src/core/NullChannel.cs
+++ b/src/core/NullChannel.cs
@@ -39,6 +39,12 @@ public sealed class NullChannel : IChannel, IAsyncDisposable
     public string Id { get; } = Guid.Empty.ToString( "N" );
 
     /// <summary>
+    /// Gets the name of the channel, which corresponds to the channel configuration name.
+    /// Always returns "NullChannel" for the null channel.
+    /// </summary>
+    public string Name { get; } = "NullChannel";
+
+    /// <summary>
     /// Gets a value indicating whether the channel is closed. Always returns true for the null channel.
     /// </summary>
     public bool IsClosed => true;

--- a/src/core/Registry/IChannelHandle.cs
+++ b/src/core/Registry/IChannelHandle.cs
@@ -1,0 +1,63 @@
+namespace Faactory.Channels;
+
+/// <summary>
+/// Interface for a channel handle, representing an active channel in the registry.
+/// </summary>
+public interface IChannelHandle
+{
+    /// <summary>
+    /// Gets the unique identifier of the channel.
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Gets the name of the channel, which corresponds to the channel configuration name.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the timestamp of when the channel was created
+    /// </summary>
+    DateTimeOffset Created { get; }
+
+    /// <summary>
+    /// Gets the timestamp of the last received message
+    /// </summary>
+    DateTimeOffset LastReceived { get; }
+
+    /// <summary>
+    /// Gets the timestamp of the last sent message
+    /// </summary>
+    DateTimeOffset LastSent { get; }
+
+    /// <summary>
+    /// Gets the total duration of the channel's existence
+    /// </summary>
+    TimeSpan Duration { get; }
+
+    /// <summary>
+    /// Gets the duration since the last received message
+    /// </summary>
+    TimeSpan IdleTime { get; }
+
+    /// <summary>
+    /// Gets the total number of bytes received
+    /// </summary>
+    long BytesReceived { get; }
+
+    /// <summary>
+    /// Gets the total number of bytes sent
+    /// </summary>
+    long BytesSent { get; }
+
+    /// <summary>
+    /// Gets the channel's metadata
+    /// </summary>
+    IReadOnlyDictionary<string, object> Data { get; }
+
+    /// <summary>
+    /// Closes the underlying channel and releases any associated resources.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous close operation.</returns>
+    Task CloseAsync();
+}

--- a/src/core/Registry/IChannelRegistrar.cs
+++ b/src/core/Registry/IChannelRegistrar.cs
@@ -1,0 +1,6 @@
+namespace Faactory.Channels;
+
+internal interface IChannelRegistrar
+{
+    void Register( IChannel channel );
+}

--- a/src/core/Registry/IChannelRegistry.cs
+++ b/src/core/Registry/IChannelRegistry.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Faactory.Channels;
+
+/// <summary>
+/// Interface for the channel registry.
+/// </summary>
+public interface IChannelRegistry
+{
+    /// <summary>
+    /// Gets the collection of currently active channels.
+    /// </summary>
+    IReadOnlyCollection<IChannelHandle> Channels { get; }
+
+    /// <summary>
+    /// Tries to get the channel handle for the specified channel ID.
+    /// </summary>
+    /// <param name="channelId">The channel ID.</param>
+    /// <param name="handle">The channel handle if found; otherwise, null.</param>
+    /// <returns>True if the channel handle was found; otherwise, false.</returns>
+    bool TryGet( string channelId, [MaybeNullWhen( false )] out IChannelHandle handle );
+}

--- a/src/core/Registry/NullChannelRegistrar.cs
+++ b/src/core/Registry/NullChannelRegistrar.cs
@@ -1,0 +1,21 @@
+namespace Faactory.Channels;
+
+/// <summary>
+/// A null implementation of the IChannelRegistrar interface that does nothing when registering a channel.
+/// </summary>
+public sealed class NullChannelRegistrar : IChannelRegistrar
+{
+    /// <summary>
+    /// Gets the singleton instance of the NullChannelRegistrar.
+    /// </summary>
+    public static NullChannelRegistrar Instance { get; } = new();
+
+    /// <summary>
+    /// Registers a channel. This implementation does nothing.
+    /// </summary>
+    /// <param name="channel">The channel to register.</param>
+    public void Register( IChannel channel )
+    {
+        // do nothing.
+    }
+}

--- a/src/websockets/ChannelFactoryExtensions.cs
+++ b/src/websockets/ChannelFactoryExtensions.cs
@@ -40,6 +40,7 @@ public static class ChannelFactoryWebSocketExtensions
         var channel = new WebSocketChannel(
             scope,
             webSocket,
+            channelName,
             options,
             inputPipeline,
             outputPipeline,

--- a/src/websockets/WebSocketChannel.cs
+++ b/src/websockets/WebSocketChannel.cs
@@ -13,7 +13,7 @@ internal sealed class WebSocketChannel : Channel, IWebSocketChannel
     private Task monitorTask = Task.CompletedTask;
     private Task receiveTask = Task.CompletedTask;
 
-    internal WebSocketChannel( IServiceScope serviceScope, WebSocket socket, ChannelOptions options, IChannelPipeline inputPipeline, IChannelPipeline outputPipeline, IEnumerable<IChannelService>? channelServices = null )
+    internal WebSocketChannel( IServiceScope serviceScope, WebSocket socket, string channelName, ChannelOptions options, IChannelPipeline inputPipeline, IChannelPipeline outputPipeline, IEnumerable<IChannelService>? channelServices = null )
         : base( serviceScope )
     {
         logger = serviceScope.ServiceProvider.GetRequiredService<ILoggerFactory>()
@@ -24,6 +24,7 @@ internal sealed class WebSocketChannel : Channel, IWebSocketChannel
         Buffer = new WritableByteBuffer( options.BufferEndianness );
         Timeout = options.IdleTimeout;
         WebSocket = socket;
+        Name = channelName;
         Input = inputPipeline;
         Output = outputPipeline;
 

--- a/tests/ChannelRegistryTests.cs
+++ b/tests/ChannelRegistryTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Faactory.Channels;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace tests;
+
+ public class ChannelRegistryTests
+ {
+    [Fact]
+    public async Task ChannelRegistry_EchoTest()
+    {
+        await using var server = await TestServer.StartAsync( channel  =>
+        {
+            // Input: whatever arrives (byte[]) => write it back (goes through output pipeline)
+            channel.AddInputHandler<byte[]>( async (ctx, data, ct) =>
+            {
+                await ctx.Channel.WriteAsync( data );
+            } );
+        } );
+
+        using var client = new System.Net.Sockets.TcpClient();
+        await client.ConnectAsync( IPAddress.Loopback, server.Port );
+
+        await Task.Delay( 200 ); // give some time for the server to accept the connection
+
+        var registry = server.Services.GetRequiredService<IChannelRegistry>();
+
+        var handle = Assert.Single( registry.Channels );
+
+        var stream = client.GetStream();
+
+        var payload = Encoding.ASCII.GetBytes( "TEST" );
+
+        await stream.WriteAsync( payload );
+        await stream.FlushAsync();
+
+        await Task.Delay( 100 ); // give some time for the server to process the write
+
+        Assert.Equal( payload.Length, handle.BytesSent );
+
+        // read exactly payload length (simple echo)
+        var received = new byte[payload.Length];
+        int read = 0;
+
+        while ( read < received.Length )
+        {
+            int n = await stream.ReadAsync( received.AsMemory( read, received.Length - read ) );
+
+            Assert.True( n > 0, "socket closed before receiving echo" );
+
+            read += n;
+        }
+
+        Assert.Equal( payload, received );
+        Assert.Equal( received.Length, handle.BytesReceived );
+
+        client.Close();
+
+        await Task.Delay( 100 ); // give some time for the server to process the close
+
+        Assert.Empty( registry.Channels );
+    }    
+ }


### PR DESCRIPTION
This PR introduces a live runtime channel registry.

```csharp
public interface IChannelRegistry
{
    IReadOnlyCollection<IChannelHandle> Channels { get; }
    bool TryGet( string channelId, [MaybeNullWhen( false )] out IChannelHandle handle );
}
```

The registry exposes operation information about active channels through `IChannelHandle`.

```csharp
public interface IChannelHandle
{
    string Id { get; }
    string Name { get; }
    DateTimeOffset Created { get; }
    DateTimeOffset LastReceived { get; }
    DateTimeOffset LastSent { get; }
    TimeSpan Duration { get; }
    TimeSpan IdleTime { get; }
    long BytesReceived { get; }
    long BytesSent { get; }
    IReadOnlyDictionary<string, object> Data { get; }

    Task CloseAsync();
}
```

### Behaviour

The registry:
- tracks active channels
- updates traffic statistics in real time
- exposes activity timestamps
- allows channels to be closed programmatically

The implementation integrates with the existing `IChannelMonitor` infrastructure to automatically update:
- bytes sent/received
- last activity timestamps
- channel lifecycle state

### Design Notes

- Registration is performed explicitly by the base channel during channel initialization
- Lifecycle updates are monitor-driven
- The registry is transport-agnostic
- No polling or background synchronization is required
- The registry exposes live runtime views of active channels

### Tests

Added unit and integration tests covering:
- channel registration/removal
- bytes/sent/received tracking
- activity timestamp updates
- full TCP lifecycle integration
- echo pipeline validation